### PR TITLE
construct functions to be defined as well as {thing}_factory

### DIFF
--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -78,6 +78,14 @@ defmodule ExMachinaTest do
     end
   end
 
+  defmodule ConstructFactory do
+    use ExMachina
+
+    def construct(:jack) do
+      %{name: "jack", age: 60}
+    end
+  end
+
   describe "sequence" do
     test "sequence/2 sequences a value" do
       assert "me-0@foo.com" == Factory.build(:email).email
@@ -108,6 +116,8 @@ defmodule ExMachinaTest do
                name: "John Doe",
                admin: false
              }
+
+      assert ConstructFactory.build(:jack, age: 50) == %{name: "jack", age: 50}
     end
 
     test "build/2 merges passed in options as keyword list" do


### PR DESCRIPTION
order of attempts:

{thing}_factory/2
{thing}_factory/1
construct/2
construct/1

(if construct/2 is defined, it will always be used instead of construct/1)


@jfeeny was interested in introspecting metadata attached to struct modules in order to provide sane defaults without needing manually to register `person_factory`, for example, you could do something like this:

```elixir
defmodule Factory do
  use ExMachina
  def construct(type) do
    struct = Module.camelize(type)
    fields = struct.describe() # __schema__ in ecto, for example
    fields
    |> Enum.map(fn {name, type} ->
      {name, default_for(type)}
    end)
    |> struct!(struct)
  end

  defp default_for(:string) do
    generate_fake_cat_name()
  end
end
```