### PR TITLE
feat: ExMachina.start/2: return a supervisor from Application callback

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -30,7 +30,12 @@ defmodule ExMachina do
   use Application
 
   @doc false
-  def start(_type, _args), do: ExMachina.Sequence.start_link()
+  def start(_type, _args) do
+    Supervisor.start_link([ExMachina.Sequence],
+      strategy: :one_for_one,
+      name: __MODULE__.Supervisor
+    )
+  end
 
   defmacro __using__(_opts) do
     quote do

--- a/lib/ex_machina/sequence.ex
+++ b/lib/ex_machina/sequence.ex
@@ -6,8 +6,10 @@ defmodule ExMachina.Sequence do
   sequential values instead of calling this module directly.
   """
 
+  use Agent
+
   @doc false
-  def start_link do
+  def start_link(_) do
     Agent.start_link(fn -> Map.new() end, name: __MODULE__)
   end
 


### PR DESCRIPTION
# Description
### ExMachina.start/2: return a supervisor from Application callback

We're actually returning the PID for an Agent rather than a
supervisor.  In addition to being against the erlang callback spec:

```
    The function is to return {ok,Pid} or {ok,Pid,State}, where Pid
    is the pid of the top supervisor and State is any term. If
    omitted, State defaults to []. If the application is stopped
    later, State is passed to Module:prep_stop/1.
```

Some tools like phoenix live dashboard will send the
application supervisor supervisor-y messages and end up crashing the
root application tree.

```
    ** (FunctionClauseError) no function clause matching in Agent.Server.handle_call/3
        (elixir 1.14.5) lib/agent/server.ex:11: Agent.Server.handle_call(:which_children, {#PID<0.22073.22>, #Reference<0.3953567925.3593732098.137638>}, %{})
        (stdlib 3.17) gen_server.erl:721: :gen_server.try_handle_call/4
        (stdlib 3.17) gen_server.erl:750: :gen_server.handle_msg/6
        (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
    Last message (from #PID<0.22073.22>): :which_children
```
This change makes ExMachina return a supervisor with a single child -
the ExMachina.Sequence.  Have also moved to `use Agent` to get the
child_spec/1 for free in ExMachina.Sequence.

This has been tested per the tool versions file (1.7.4 + otp 21).

```
 lib/ex_machina.ex          | 7 ++++++-
 lib/ex_machina/sequence.ex | 4 +++-
 2 files changed, 9 insertions(+), 2 deletions(-)
```

# Before

![ex_machina_crashing_in_livedashboard mov](https://github.com/beam-community/ex_machina/assets/130169/ef31463c-2190-4f71-92a4-d6a22665a9bf)

    
# Afterwards

![image](https://github.com/beam-community/ex_machina/assets/130169/d99c35d0-481d-43c7-8505-a8552a0c8772)

# Tests

```
test@742e43ef2efc:/ex_machina$ mix test
[...]
==> ex_machina
Compiling 16 files (.ex)
Generated ex_machina app
The database for ExMachina.TestRepo has been dropped
The database for ExMachina.TestRepo has been created
....................................................................................

Finished in 0.2 seconds
84 tests, 0 failures

Randomized with seed 422393
test@742e43ef2efc:/ex_machina$ elixir --version
Erlang/OTP 21 [erts-10.3.5.19] [source] [64-bit] [smp:5:5] [ds:5:5:10] [async-threads:1]

Elixir 1.7.4 (compiled with Erlang/OTP 21)
```